### PR TITLE
Improve browser isolation for Behave tests

### DIFF
--- a/features/environment.py
+++ b/features/environment.py
@@ -1,0 +1,22 @@
+import os
+import shutil
+import tempfile
+from selenium import webdriver
+from selenium.webdriver.chrome.options import Options
+
+
+def before_scenario(context, scenario):
+    context.chrome_profile_dir = tempfile.mkdtemp(prefix="selenium-profile-")
+    options = Options()
+    options.add_argument(f"--user-data-dir={context.chrome_profile_dir}")
+    options.add_argument("--headless=new")
+    options.add_argument("--no-sandbox")
+    options.add_argument("--disable-dev-shm-usage")
+    context.browser = webdriver.Chrome(options=options)
+
+
+def after_scenario(context, scenario):
+    if hasattr(context, "browser"):
+        context.browser.quit()
+    if getattr(context, "chrome_profile_dir", None):
+        shutil.rmtree(context.chrome_profile_dir, ignore_errors=True)

--- a/features/login.feature
+++ b/features/login.feature
@@ -1,0 +1,4 @@
+Feature: Login
+  Scenario: Dummy login
+    Given I open a blank page
+    Then the title should contain ""

--- a/features/steps/login_steps.py
+++ b/features/steps/login_steps.py
@@ -1,0 +1,9 @@
+from behave import given, then
+
+@given('I open a blank page')
+def step_open_blank(context):
+    context.browser.get('about:blank')
+
+@then('the title should contain ""')
+def step_title(context):
+    assert context.browser.title == ''

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+behave
+selenium


### PR DESCRIPTION
## Summary
- configure Chrome in `before_scenario` to use a temporary profile and run headless
- clean up the temp profile in `after_scenario`
- add minimal Behave scenario for testing

## Testing
- `pip install -r requirements.txt`
- `behave`

------
https://chatgpt.com/codex/tasks/task_e_6841b8c5e4f083339c74bc033c1fbccf